### PR TITLE
Fix bash syntax for output redirection and document certificate sub dire...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ How-to
 
 Save the script somewhere on your system.
 
-Once done, add a new directory in the directory where you stored the script and place the certificates in this directory which you want to add to the phone's database. For CAcert, this would be the class 3 root certificate in PEM format as found on the [CAcert website](https://www.cacert.org/index.php?id=3).
+Once done, add a new directory in the directory where you stored the script and place the certificates which you want to add to the phone's database in the sub directory 'certs'. For CAcert, this would be the class 3 root certificate in PEM format as found on the [CAcert website](https://www.cacert.org/index.php?id=3).
 
 Then simply run the script.
 

--- a/add-certificates-to-phone.sh
+++ b/add-certificates-to-phone.sh
@@ -5,7 +5,7 @@ ROOT_DIR_DB=/data/b2g/mozilla
 CERT=cert9.db
 KEY=key4.db
 PKCS11=pkcs11.txt
-DB_DIR=`adb shell "ls -d ${ROOT_DIR_DB}/*.default 2&gt;/dev/null" | sed "s/default.*$/default/g"`
+DB_DIR=`adb shell "ls -d ${ROOT_DIR_DB}/*.default 2>/dev/null" | sed "s/default.*$/default/g"`
 
 if [ "${DB_DIR}" = "" ]; then
   echo "Profile directory does not exists. Please start the b2g process at


### PR DESCRIPTION
...ctory

As commented by a user on https://www.pending.io/add-cacert-root-certificate-to-firefox-os/#comment-75, the script had a syntax error in the output redirection (probably caused by the blog software).
Also, I added a note because the certificates to be used have to placed into a sub directory called 'certs'.
